### PR TITLE
feat: Ads/eng 1807 example agents add auth token to sensitive data extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ local files, Github repos, S3 buckets, and other cloud storage systems.
 # Local
 uv run -m sensitive_data_extraction --model <model> --path /path/to/local/files
 
-# Optional: Pass a GH token
-$ gh auth token
-uv run -m sensitive_data_extraction --model <model> --path /path/to/local/files --github-token <gh-auth-token>
-
 # S3
 uv run -m sensitive_data_extraction --model <model> --path s3://bucket
 
@@ -100,6 +96,10 @@ uv run -m sensitive_data_extraction --model <model> --path gcs://bucket
 
 # Github
 uv run -m sensitive_data_extraction --model <model> --path github://owner:repo@/
+
+# Optional: Pass a GH token
+$ gh auth token
+uv run -m sensitive_data_extraction --model <model> --path github://owner:repo@/ --github-token <gh-auth-token>
 ```
 
 Check out the their docs for more options:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ local files, Github repos, S3 buckets, and other cloud storage systems.
 
 ```bash
 # Local
-uv run -m sensitive_data_extraction --model <model> --path /path/to/local/files 
+uv run -m sensitive_data_extraction --model <model> --path /path/to/local/files
+
+# Optional: Pass a GH token
+$ gh auth token
+uv run -m sensitive_data_extraction --model <model> --path /path/to/local/files --github-token <gh-auth-token>
 
 # S3
 uv run -m sensitive_data_extraction --model <model> --path s3://bucket

--- a/sensitive_data_extraction/main.py
+++ b/sensitive_data_extraction/main.py
@@ -29,6 +29,8 @@ class Args:
     """Maximum number of iterations per agent"""
     fs: dict[str, str] = field(default_factory=dict)
     """Options for the fsspec filesystem (e.g. `fs-options.anon true`)"""
+    github_token: str | None = None
+    """GitHub token for authentication"""
     log_level: str = "INFO"
     """Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"""
 
@@ -150,10 +152,15 @@ async def agent(*, args: Args, dn_args: DreadnodeArgs | None = None) -> None:
             max_steps=args.max_steps,
         )
 
+        fs_options = dict(args.fs)
+        if args.github_token and args.path.startswith("github://"):
+            fs_options["token"] = args.github_token
+            fs_options["username"] = "github-user"
+
         filesystem = FilesystemTools(
             args.path,
             mode="read-only",
-            fs_options=args.fs,
+            fs_options=fs_options,
         )
 
         generator = rg.get_generator(args.model)


### PR DESCRIPTION
optional GitHub authentication handler which allows the tool to authenticate with GitHub's API when accessing private repositories with the format `github://owner:repo@/` by passing the `--github-token` parameter

tested with multiple runs (concurrent & sequential) following changes to GitHub and did not receive prior `403` errors from the GH API (for rate-limiting and private-repos). also tested with s3 ([buckets](https://buckets.grayhatwarfare.com/buckets?type=aws)) after changes in the commit to ensure that the `--github-token` parameter is not passed to the s3 client or causing any other problems to any other fs handlers