### PR TITLE
fix: build_challenges function not honouring challenges param

### DIFF
--- a/dangerous_capabilities/challenges.py
+++ b/dangerous_capabilities/challenges.py
@@ -144,7 +144,7 @@ async def start_containers(
     # Check if any of the container
     logger.info(f"Started {len(containers)} containers for '{challenge.name}'")
     for container in containers:
-        logger.info(f'  |- {container["Config"]["Image"]} ({container["Name"]})')
+        logger.info(f"  |- {container['Config']['Image']} ({container['Name']})")
 
     async def container_exec(
         cmd: str,
@@ -193,9 +193,18 @@ async def start_containers(
         await docker_client.close()
 
 
-async def build_challenges(flag: str, *, rebuild: bool = False) -> list[Challenge]:
+async def build_challenges(
+    flag: str,
+    *,
+    rebuild: bool = False,
+    challenge_names: list[str] | None = None,
+) -> list[Challenge]:
     with (challenges_dir / "challenges.json").open() as f:
         challenges = [Challenge(**challenge) for challenge in json.load(f)]
+
+    # Filter challenges from param
+    if challenge_names:
+        challenges = [c for c in challenges if c.name in challenge_names]
 
     container_paths = {
         container.path for challenge in challenges for container in challenge.containers

--- a/dangerous_capabilities/main.py
+++ b/dangerous_capabilities/main.py
@@ -243,19 +243,17 @@ async def main(*, args: Args, dn_args: DreadnodeArgs | None = None) -> None:
         console=dn_args.console,
     )
 
-    # Load Challenges
+    # Load and filter challenges
+    challenges = await build_challenges(
+        args.flag,
+        rebuild=args.rebuild,
+        challenge_names=args.challenges,
+    )
 
-    challenges = await build_challenges(args.flag, rebuild=args.rebuild)
-
-    if args.challenges:
-        for arg_challenge in args.challenges:
-            if arg_challenge not in {c.name for c in challenges}:
-                logger.error(
-                    f"Challenge '{arg_challenge}' not in ({', '.join(c.name for c in challenges)}).",
-                )
-                return
-
-        challenges = [c for c in challenges if c.name in args.challenges]
+    # Just validate that we got some challenges back
+    if not challenges:
+        logger.error("No challenges found or all requested challenges are invalid.")
+        return
 
     # Create Agents
 


### PR DESCRIPTION
found a bug in the `build_challenges` [function](https://github.com/dreadnode/example-agents/blob/b5c59fda1e7f87808debfdd36235685bb4b1953e/dangerous_capabilities/challenges.py#L196) is not honouring the param `--challenges` set via the CLI and by default building all challenges, ie:

```bash
uv run -m dangerous_capabilities
--model groq/meta-llama/llama-4-scout-17b-16e-instruct
--concurrency 2
--token "$DREADNODE_TOKEN"
--server "[https://platform.dreadnode.io](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)"
--challenges ssh
--project radads
12:08:45.619 | Pruning networks ...
12:08:45.624 | Building 14 containers ...
12:08:45.714 | |- Found flask_idor:latest, skipping build
12:08:45.830 | |- Found webmin:latest, skipping build
12:08:45.967 | |- Found grafana:latest, skipping build
12:08:46.098 | |- Found flask_cmd_injection:latest, skipping build
12:08:46.104 | |- Building kali:latest (/Users/ads/git/example-agents/dangerous_capabilities/challenges/kali)
Step 1/10 : FROM kalilinux/kali-rolling
```


the `build_challenges()` function was building ALL containers before the challenge filtering happened in `main.py`

verified following these changes that both the `--challenges` param correctly filters and without it specified builds all challenge containers
